### PR TITLE
Minor refactoring so that for dependencies to refer to the Centrifuge Substrate fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,18 +8,6 @@ edition = "2018"
 frame-support = { branch = "master", git = "https://github.com/centrifuge/substrate.git", default-features = false }
 sp-std = { branch = "master", git = "https://github.com/centrifuge/substrate", default-features = false }
 
-#[dependencies.frame-support]
-#default-features = false
-#git = 'https://github.com/centrifuge/substrate.git'
-#rev = 'e271ae7fda72a7ad55ff3c216b8b2abae0ae31fd'
-#version = '2.0.0-rc6'
-
-#[dependencies.sp-std]
-#default-features = false
-#git = 'https://github.com/centrifuge/substrate.git'
-#rev = 'e271ae7fda72a7ad55ff3c216b8b2abae0ae31fd'
-#version = '2.0.0-rc6'
-
 [features]
 default = [ "std" ]
 std = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,17 +4,21 @@ version = "0.1.0"
 authors = ["Jay Butera <buterajay@protonmail.com>"]
 edition = "2018"
 
-[dependencies.frame-support]
-default-features = false
-git = 'https://github.com/centrifuge/substrate.git'
-rev = 'e271ae7fda72a7ad55ff3c216b8b2abae0ae31fd'
-version = '2.0.0-rc6'
+[dependencies]
+frame-support = { branch = "master", git = "https://github.com/centrifuge/substrate.git", default-features = false }
+sp-std = { branch = "master", git = "https://github.com/centrifuge/substrate", default-features = false }
 
-[dependencies.sp-std]
-default-features = false
-git = 'https://github.com/centrifuge/substrate.git'
-rev = 'e271ae7fda72a7ad55ff3c216b8b2abae0ae31fd'
-version = '2.0.0-rc6'
+#[dependencies.frame-support]
+#default-features = false
+#git = 'https://github.com/centrifuge/substrate.git'
+#rev = 'e271ae7fda72a7ad55ff3c216b8b2abae0ae31fd'
+#version = '2.0.0-rc6'
+
+#[dependencies.sp-std]
+#default-features = false
+#git = 'https://github.com/centrifuge/substrate.git'
+#rev = 'e271ae7fda72a7ad55ff3c216b8b2abae0ae31fd'
+#version = '2.0.0-rc6'
 
 [features]
 default = [ "std" ]


### PR DESCRIPTION
- Set Substrate dependencies (in `Cargo.toml`) to forked Centrifuge Substrate repository